### PR TITLE
Detect and use existing Malmo installations

### DIFF
--- a/minecraft_py/__init__.py
+++ b/minecraft_py/__init__.py
@@ -10,21 +10,24 @@ import psutil
 
 logger = logging.getLogger(__name__)
 
-# determine Malmo location and executable name
-malmo_dir = os.path.join(os.path.dirname(__file__), 'Malmo')
+malmo_xsd_path = os.environ["MALMO_XSD_PATH"]
+malmo_dir = os.path.basename(malmo_xsd_path)
+
+# # determine Malmo location and executable name
+# malmo_dir = os.path.join(os.path.dirname(__file__), 'Malmo')
 minecraft_dir = os.path.join(malmo_dir, 'Minecraft')
 if platform.system() == 'Windows':
     mc_command = os.path.join(minecraft_dir, 'launchClient.bat')
 else:
     mc_command = os.path.join(minecraft_dir, 'launchClient.sh')
 
-# set MALMO_XSD_PATH environment variable
-malmo_xsd_path = os.path.join(malmo_dir, 'Schemas')
-os.environ['MALMO_XSD_PATH'] = malmo_xsd_path
+# # set MALMO_XSD_PATH environment variable
+# malmo_xsd_path = os.path.join(malmo_dir, 'Schemas')
+# os.environ['MALMO_XSD_PATH'] = malmo_xsd_path
 
-# add MalmoPython to PYTHONPATH
-malmo_python_path = os.path.join(malmo_dir, 'Python_Examples')
-sys.path.append(malmo_python_path)
+# # add MalmoPython to PYTHONPATH
+# malmo_python_path = os.path.join(malmo_dir, 'Python_Examples')
+# sys.path.append(malmo_python_path)
 
 def is_port_taken(port, address='0.0.0.0'):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/minecraft_py/__init__.py
+++ b/minecraft_py/__init__.py
@@ -11,7 +11,7 @@ import psutil
 logger = logging.getLogger(__name__)
 
 malmo_xsd_path = os.environ["MALMO_XSD_PATH"]
-malmo_dir = os.path.basename(malmo_xsd_path)
+malmo_dir = os.path.dirname(malmo_xsd_path)
 
 # # determine Malmo location and executable name
 # malmo_dir = os.path.join(os.path.dirname(__file__), 'Malmo')

--- a/minecraft_py/__init__.py
+++ b/minecraft_py/__init__.py
@@ -10,24 +10,27 @@ import psutil
 
 logger = logging.getLogger(__name__)
 
-malmo_xsd_path = os.environ["MALMO_XSD_PATH"]
-malmo_dir = os.path.dirname(malmo_xsd_path)
+# if a global Malmo installation exists, use that
+if "MALMO_XSD_PATH" in os.environ:
+    malmo_xsd_path = os.environ["MALMO_XSD_PATH"]
+    malmo_dir = os.path.dirname(malmo_xsd_path)
+# otherwise, use the local Malmo installation
+else:
+    malmo_dir = os.path.join(os.path.dirname(__file__), 'Malmo')
+    # set MALMO_XSD_PATH environment variable
+    malmo_xsd_path = os.path.join(malmo_dir, 'Schemas')
+    os.environ['MALMO_XSD_PATH'] = malmo_xsd_path
 
-# # determine Malmo location and executable name
-# malmo_dir = os.path.join(os.path.dirname(__file__), 'Malmo')
+# determine Malmo location and executable name
 minecraft_dir = os.path.join(malmo_dir, 'Minecraft')
 if platform.system() == 'Windows':
     mc_command = os.path.join(minecraft_dir, 'launchClient.bat')
 else:
     mc_command = os.path.join(minecraft_dir, 'launchClient.sh')
 
-# # set MALMO_XSD_PATH environment variable
-# malmo_xsd_path = os.path.join(malmo_dir, 'Schemas')
-# os.environ['MALMO_XSD_PATH'] = malmo_xsd_path
-
-# # add MalmoPython to PYTHONPATH
-# malmo_python_path = os.path.join(malmo_dir, 'Python_Examples')
-# sys.path.append(malmo_python_path)
+# add MalmoPython to PYTHONPATH
+malmo_python_path = os.path.join(malmo_dir, 'Python_Examples')
+sys.path.append(malmo_python_path)
 
 def is_port_taken(port, address='0.0.0.0'):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='minecraft-py',
-      version='0.0.2.1',
+      version='0.0.2',
       description='Python bindings for Malmo',
       url='https://github.com/tambetm/minecraft-py',
       author='Tambet Matiisen',

--- a/setup.py
+++ b/setup.py
@@ -1,60 +1,66 @@
 from __future__ import print_function
 
-# import os
-# import stat
-# import shutil
-# import urllib
-# import zipfile
-# import platform
+import os
+import stat
+import shutil
+import urllib
+import zipfile
+import platform
 
-# from distutils.command.build import build
-# from setuptools.command.install import install
+from distutils.command.build import build
+from setuptools.command.install import install
 from setuptools import setup, find_packages
 
-# def make_executable(path):
-#     st = os.stat(path)
-#     os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+def make_executable(path):
+    st = os.stat(path)
+    os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 # For building Malmo
-# class BuildMalmo(build):
-#     def run(self):
-#         from future.moves.urllib.request import urlretrieve
+class BuildMalmo(build):
+    def run(self):
+        # abort if a global Malmo installation already exists and just use that
+        if "MALMO_XSD_PATH" in os.environ:
+            build.run(self)
+            return
 
-#         malmo_ver = '0.18.0'
+        # otherwise, install a new local Malmo
+        from future.moves.urllib.request import urlretrieve
 
-#         if os.path.exists('minecraft_py/Malmo'):
-#             print("Removing existing Malmo folder...")
-#             shutil.rmtree('minecraft_py/Malmo')
+        malmo_ver = '0.18.0'
 
-#         system = platform.system()
-#         bits, linkage = platform.architecture()
-#         if system == 'Linux':
-#             dist, version, vername = platform.linux_distribution()
-#             folder = 'Malmo-{}-{}-{}-{}-{}'.format(malmo_ver, system, dist, version, bits)
-#         elif system == 'Darwin':
-#             folder = 'Malmo-{}-Mac-{}'.format(malmo_ver, bits)
-#         else:
-#             folder = 'Malmo-{}-{}-{}'.format(malmo_ver, system, bits)
-#         url = 'https://github.com/Microsoft/malmo/releases/download/{}/{}.zip'.format(malmo_ver, folder)
+        if os.path.exists('minecraft_py/Malmo'):
+            print("Removing existing Malmo folder...")
+            shutil.rmtree('minecraft_py/Malmo')
 
-#         print("Downloading Malmo...")
-#         urlretrieve(url, 'Malmo.zip')
+        system = platform.system()
+        bits, linkage = platform.architecture()
+        if system == 'Linux':
+            dist, version, vername = platform.linux_distribution()
+            folder = 'Malmo-{}-{}-{}-{}-{}'.format(malmo_ver, system, dist, version, bits)
+        elif system == 'Darwin':
+            folder = 'Malmo-{}-Mac-{}'.format(malmo_ver, bits)
+        else:
+            folder = 'Malmo-{}-{}-{}'.format(malmo_ver, system, bits)
+        url = 'https://github.com/Microsoft/malmo/releases/download/{}/{}.zip'.format(malmo_ver, folder)
 
-#         print("Unzipping Malmo...")
-#         zip = zipfile.ZipFile('Malmo.zip')
-#         zip.extractall('minecraft_py')
-#         zip.close()
+        print("Downloading Malmo...")
+        urlretrieve(url, 'Malmo.zip')
 
-#         print("Removing zip...")
-#         os.remove('Malmo.zip')
-#         print("Renaming folder...")
-#         os.rename(os.path.join('minecraft_py', folder), 'minecraft_py/Malmo')
+        print("Unzipping Malmo...")
+        zip = zipfile.ZipFile('Malmo.zip')
+        zip.extractall('minecraft_py')
+        zip.close()
 
-#         print("Changing permissions...")
-#         make_executable('minecraft_py/Malmo/Minecraft/gradlew')
-#         make_executable('minecraft_py/Malmo/Minecraft/launchClient.sh')
+        print("Removing zip...")
+        os.remove('Malmo.zip')
+        print("Renaming folder...")
+        os.rename(os.path.join('minecraft_py', folder), 'minecraft_py/Malmo')
 
-#         build.run(self)
+        print("Changing permissions...")
+        make_executable('minecraft_py/Malmo/Minecraft/gradlew')
+        make_executable('minecraft_py/Malmo/Minecraft/launchClient.sh')
+
+        build.run(self)
 
 
 setup(name='minecraft-py',
@@ -64,7 +70,7 @@ setup(name='minecraft-py',
       author='Tambet Matiisen',
       author_email='tambet.matiisen@gmail.com',
       packages=find_packages(),
-      # cmdclass={'build_ext': BuildMalmo},
+      cmdclass={'build_ext': BuildMalmo},
       setup_requires=['future'],
       install_requires=['psutil'],
       include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,70 +1,70 @@
 from __future__ import print_function
 
-import os
-import stat
-import shutil
-import urllib
-import zipfile
-import platform
+# import os
+# import stat
+# import shutil
+# import urllib
+# import zipfile
+# import platform
 
-from distutils.command.build import build
-from setuptools.command.install import install
+# from distutils.command.build import build
+# from setuptools.command.install import install
 from setuptools import setup, find_packages
 
-def make_executable(path):
-    st = os.stat(path)
-    os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+# def make_executable(path):
+#     st = os.stat(path)
+#     os.chmod(path, st.st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 # For building Malmo
-class BuildMalmo(build):
-    def run(self):
-        from future.moves.urllib.request import urlretrieve
+# class BuildMalmo(build):
+#     def run(self):
+#         from future.moves.urllib.request import urlretrieve
 
-        malmo_ver = '0.18.0'
+#         malmo_ver = '0.18.0'
 
-        if os.path.exists('minecraft_py/Malmo'):
-            print("Removing existing Malmo folder...")
-            shutil.rmtree('minecraft_py/Malmo')
+#         if os.path.exists('minecraft_py/Malmo'):
+#             print("Removing existing Malmo folder...")
+#             shutil.rmtree('minecraft_py/Malmo')
 
-        system = platform.system()
-        bits, linkage = platform.architecture()
-        if system == 'Linux':
-            dist, version, vername = platform.linux_distribution()
-            folder = 'Malmo-{}-{}-{}-{}-{}'.format(malmo_ver, system, dist, version, bits)
-        elif system == 'Darwin':
-            folder = 'Malmo-{}-Mac-{}'.format(malmo_ver, bits)
-        else:
-            folder = 'Malmo-{}-{}-{}'.format(malmo_ver, system, bits)
-        url = 'https://github.com/Microsoft/malmo/releases/download/{}/{}.zip'.format(malmo_ver, folder)
+#         system = platform.system()
+#         bits, linkage = platform.architecture()
+#         if system == 'Linux':
+#             dist, version, vername = platform.linux_distribution()
+#             folder = 'Malmo-{}-{}-{}-{}-{}'.format(malmo_ver, system, dist, version, bits)
+#         elif system == 'Darwin':
+#             folder = 'Malmo-{}-Mac-{}'.format(malmo_ver, bits)
+#         else:
+#             folder = 'Malmo-{}-{}-{}'.format(malmo_ver, system, bits)
+#         url = 'https://github.com/Microsoft/malmo/releases/download/{}/{}.zip'.format(malmo_ver, folder)
 
-        print("Downloading Malmo...")
-        urlretrieve(url, 'Malmo.zip')
-        
-        print("Unzipping Malmo...")
-        zip = zipfile.ZipFile('Malmo.zip')
-        zip.extractall('minecraft_py')
-        zip.close()
-        
-        print("Removing zip...")
-        os.remove('Malmo.zip')
-        print("Renaming folder...")
-        os.rename(os.path.join('minecraft_py', folder), 'minecraft_py/Malmo')
+#         print("Downloading Malmo...")
+#         urlretrieve(url, 'Malmo.zip')
 
-        print("Changing permissions...")
-        make_executable('minecraft_py/Malmo/Minecraft/gradlew')
-        make_executable('minecraft_py/Malmo/Minecraft/launchClient.sh')
+#         print("Unzipping Malmo...")
+#         zip = zipfile.ZipFile('Malmo.zip')
+#         zip.extractall('minecraft_py')
+#         zip.close()
 
-        build.run(self)
+#         print("Removing zip...")
+#         os.remove('Malmo.zip')
+#         print("Renaming folder...")
+#         os.rename(os.path.join('minecraft_py', folder), 'minecraft_py/Malmo')
+
+#         print("Changing permissions...")
+#         make_executable('minecraft_py/Malmo/Minecraft/gradlew')
+#         make_executable('minecraft_py/Malmo/Minecraft/launchClient.sh')
+
+#         build.run(self)
 
 
 setup(name='minecraft-py',
-      version='0.0.2',
+      version='0.0.2.1',
       description='Python bindings for Malmo',
       url='https://github.com/tambetm/minecraft-py',
       author='Tambet Matiisen',
       author_email='tambet.matiisen@gmail.com',
       packages=find_packages(),
-      cmdclass={'build_ext': BuildMalmo},
+      # cmdclass={'build_ext': BuildMalmo},
       setup_requires=['future'],
       install_requires=['psutil'],
       include_package_data=True,


### PR DESCRIPTION
If `MALMO_XSD_PATH` already exists, just use the Malmo installation there instead of creating a new local one.  This works because the installation script automatically sets `MALMO_XSD_PATH`. The rationale for this is to allow for the use of the standard Microsoft installation instructions as well as to support any Malmo version.